### PR TITLE
Unicode Fehler bei Dateien mit Umlaut im Filenamen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix encoding problem with nested folders containing umlauts in the title.
+  [jone]
 
 
 1.0.0 (2013-09-13)

--- a/ftw/zipexport/representations/archetypes.py
+++ b/ftw/zipexport/representations/archetypes.py
@@ -19,7 +19,7 @@ class FolderZipRepresentation(NullZipRepresentation):
         brains = self.context.getFolderContents()
         content = [brain.getObject() for brain in brains]
         if not toplevel:
-            path_prefix += "/" + self.context.title
+            path_prefix += "/" + self.context.Title()
 
         for obj in content:
             adapt = getMultiAdapter((obj, self.request),

--- a/ftw/zipexport/tests/test_export.py
+++ b/ftw/zipexport/tests/test_export.py
@@ -1,0 +1,29 @@
+from ZPublisher.Iterators import filestream_iterator
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.zipexport.testing import FTW_ZIPEXPORT_FUNCTIONAL_TESTING
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+
+class TestExport(TestCase):
+
+    layer = FTW_ZIPEXPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+
+    def test_export_files_with_umlauts_in_title(self):
+        folder = create(Builder('folder'))
+        subfolder = create(Builder('folder')
+                           .titled('f\xc3\xb6lder')
+                           .within(folder))
+
+        create(Builder('file')
+               .titled('hall\xc3\xb6chen')
+               .attach_file_containing('Testdata', 'hall\xc3\xb6chen.pdf')
+               .within(subfolder))
+
+        view = folder.restrictedTraverse('zip_export')
+        self.assertEquals(filestream_iterator, type(view()))

--- a/ftw/zipexport/zipexportview.py
+++ b/ftw/zipexport/zipexportview.py
@@ -45,7 +45,7 @@ class ZipSelectedExportView(BrowserView):
             zip_file = generator.generate()
             filename = '%s.zip' % self.context.title
             response.setHeader("Content-Disposition",
-                                 'inline; filename="%s"' % filename)
+                                 'inline; filename="%s"' % filename.encode('utf-8'))
             response.setHeader("Content-type", "application/zip")
             response.setHeader("Content-Length", os.stat(zip_file.name).st_size)
 


### PR DESCRIPTION
Bei http://demo.4teamwork.ch/helbling.teamraum.ch/platform/projekte/stefanies-teamraum

gibt es einen Unicode Fehler beim Zip Export:

Zeit
16.09.2013 21:54
Benutzername
stefanie.muster@4teamwork.ch (stefanie.muster@4teamwork.ch)
Anfrage URL
http://demo.4teamwork.ch/helbling.teamraum.ch/platform/projekte/stefanies-teamraum/zip_export
Fehlertyp
UnicodeDecodeError
Fehlerwert
'ascii' codec can't decode byte 0xcc in position 5: ordinal not in range(128)
Traceback (innermost last):

Module ZPublisher.Publish, line 60, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 46, in call_object
Module ftw.zipexport.zipexportview, line 61, in **call**
Module ftw.zipexport.zipexportview, line 33, in zip_selected
Module ftw.zipexport.representations.archetypes, line 30, in get_files
Module ftw.zipexport.representations.archetypes, line 30, in get_files
Module ftw.zipexport.representations.archetypes, line 40, in get_files
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 5: ordinal not in range(128)
