### PR TITLE
Handle multiple files with the same filename.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Added handling for files with same filename.
+  [lknoepfel]
 
 1.1.0 (2013-10-14)
 ------------------

--- a/ftw/zipexport/generation.py
+++ b/ftw/zipexport/generation.py
@@ -1,5 +1,7 @@
 from tempfile import NamedTemporaryFile
 from ftw.zipexport.zipfilestream import ZipFile
+import os
+import sys
 
 
 class ZipGenerator(object):
@@ -23,12 +25,29 @@ class ZipGenerator(object):
         self.tmp_file.__exit__(exc_type, exc_value, traceback)
 
     def add_file(self, file_path, file_pointer):
+        # paths in zipfile do not have a / at the root
+        file_path = file_path.strip('/')
+
+        file_path = self.generate_unique_filepath(file_path)
+
         try:
             self.zip_file.writefile(file_pointer, file_path)
         except RuntimeError:
             raise StandardError("ZipFile already generated/closed.\
                 Please add all files before generating.")
         self.empty = False
+
+    def generate_unique_filepath(self, file_path):
+        if file_path not in self.zip_file.namelist():
+            return file_path
+
+        path, name = os.path.split(file_path)
+        name, ext = os.path.splitext(name)
+
+        for i in xrange(2, sys.maxint):
+            new_filename = os.path.join(path, '%s (%d)%s' % (name, i, ext))
+            if new_filename not in self.zip_file.namelist():
+                return new_filename
 
     @property
     def is_empty(self):


### PR DESCRIPTION
If there are files with the same Filename only one will show up in the zipfile.
Observed when tried to export some mails. They apparently all have the filename message.eml.

Adding numbers to the filename would eliminate this problem. Like message.eml, message1.eml..
