### PR TITLE
zip_export view does not respect it's own settings

### DIFF
--- a/ftw/zipexport/locales/de/LC_MESSAGES/ftw.zipexport.po
+++ b/ftw/zipexport/locales/de/LC_MESSAGES/ftw.zipexport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-06 10:13+0000\n"
+"POT-Creation-Date: 2013-09-04 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,23 +10,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
 
 #: ./ftw/zipexport/profiles/default/actions.xml
-#: ./ftw/zipexport/profiles/documentaction/actions.xml
 msgid "Export as Zip"
 msgstr "Als Zip-Datei exportieren"
 
 #: ./ftw/zipexport/profiles/default/actions.xml
-#: ./ftw/zipexport/profiles/documentaction/actions.xml
 msgid "Export data from plone into a zip archive."
 msgstr "Exportiert Inhalte aus Plone als Zip-Archiv."
 
 #. Default: "Zip export is not supported on the selected content."
-#: ./ftw/zipexport/browser/zipexportview.py:51
+#: ./ftw/zipexport/zipexportview.py:39
 msgid "statmsg_content_not_supported"
 msgstr "Der ausgewählte Inhalt unterstützt keinen Zip Export."
 
-#. Default: "Zip export is not allowed on the selected content."
-#: ./ftw/zipexport/browser/zipexportview.py:33
-msgid "statmsg_export_not_allowed"
-msgstr "Der Zip Export ist auf dem ausgewählten Inhalt nicht erlaubt."
+

--- a/ftw/zipexport/locales/fr/LC_MESSAGES/ftw.zipexport.po
+++ b/ftw/zipexport/locales/fr/LC_MESSAGES/ftw.zipexport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-06 10:13+0000\n"
+"POT-Creation-Date: 2013-09-04 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,21 +12,16 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/zipexport/profiles/default/actions.xml
-#: ./ftw/zipexport/profiles/documentaction/actions.xml
 msgid "Export as Zip"
 msgstr "Exporter comme fichier ZIP"
 
 #: ./ftw/zipexport/profiles/default/actions.xml
-#: ./ftw/zipexport/profiles/documentaction/actions.xml
 msgid "Export data from plone into a zip archive."
 msgstr "Exportation de données de Plone dans des archives ZIP."
 
 #. Default: "Zip export is not supported on the selected content."
-#: ./ftw/zipexport/browser/zipexportview.py:51
+#: ./ftw/zipexport/zipexportview.py:39
 msgid "statmsg_content_not_supported"
 msgstr "L'exportation ZIP n'est pas soutenue pour le contenu choisi."
 
-#. Default: "Zip export is not allowed on the selected content."
-#: ./ftw/zipexport/browser/zipexportview.py:33
-msgid "statmsg_export_not_allowed"
-msgstr "L'exportation ZIP n'est pas autorisée sur le contenu sélectionné."
+

--- a/ftw/zipexport/locales/ftw.zipexport.pot
+++ b/ftw/zipexport/locales/ftw.zipexport.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-06 10:13+0000\n"
+"POT-Creation-Date: 2013-09-04 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,26 +12,21 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
+"Domain: ftw.zipexport\n"
 
 #: ./ftw/zipexport/profiles/default/actions.xml
-#: ./ftw/zipexport/profiles/documentaction/actions.xml
 msgid "Export as Zip"
 msgstr ""
 
 #: ./ftw/zipexport/profiles/default/actions.xml
-#: ./ftw/zipexport/profiles/documentaction/actions.xml
 msgid "Export data from plone into a zip archive."
 msgstr ""
 
 #. Default: "Zip export is not supported on the selected content."
-#: ./ftw/zipexport/browser/zipexportview.py:51
+#: ./ftw/zipexport/zipexportview.py:39
 msgid "statmsg_content_not_supported"
 msgstr ""
-
-#. Default: "Zip export is not allowed on the selected content."
-#: ./ftw/zipexport/browser/zipexportview.py:33
-msgid "statmsg_export_not_allowed"
-msgstr ""
-
 


### PR DESCRIPTION
it's possible to configure the zip download doc action. 

![screen shot 2014-05-05 at 09 21 42](https://cloud.githubusercontent.com/assets/437933/2875761/27d28e74-d426-11e3-8bd8-d8f6fa62a29a.png)

But it's still possible to call the `zip_download` view on other content. 
