### PR TITLE
Make export possible on multiple interfaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Added option to select multiple interfaces on which the export is available.
+  [lknoepfel]
+
 - Added error message when the content is too big to zip.
   This happens when the ZIP64 isn't available and the content is bigger than 4GB.
   [lknoepfel]

--- a/ftw/zipexport/browser/available.py
+++ b/ftw/zipexport/browser/available.py
@@ -14,10 +14,18 @@ class ZipExportEnabled(BrowserView):
         """ Checks if context is marked as zip exportable.
         """
         registry = getUtility(IRegistry)
-        reg_proxy = registry.forInterface(IZipExportSettings)
         try:
-            interface_class = resolve(reg_proxy.enabled_dotted_name)
-        except ImportError:
+            reg_proxy = registry.forInterface(IZipExportSettings)
+        except KeyError:
             return False
 
-        return interface_class and interface_class.providedBy(self.context)
+        for dotted_name in reg_proxy.enabled_dotted_names:
+            try:
+                interface_class = resolve(dotted_name)
+            except ImportError:
+                continue
+
+            if interface_class and interface_class.providedBy(self.context):
+                return True
+
+        return False

--- a/ftw/zipexport/interfaces.py
+++ b/ftw/zipexport/interfaces.py
@@ -3,9 +3,10 @@ from zope.interface import Interface
 
 
 class IZipExportSettings(Interface):
-    enabled_dotted_name = schema.TextLine(
-        title=u"Interface dotted-name on which zipexport is enabled.",
-        default=u"Products.CMFCore.interfaces._content.IContentish")
+    enabled_dotted_names = schema.List(
+        title=u"Interface dotted-names on which zipexport is enabled.",
+        default=[u"Products.CMFCore.interfaces._content.IContentish"],
+        value_type=schema.TextLine())
 
 
 class IZipRepresentation(Interface):

--- a/ftw/zipexport/tests/test_export_limitation.py
+++ b/ftw/zipexport/tests/test_export_limitation.py
@@ -37,7 +37,7 @@ class TestExportView(TestCase):
     def test_export_is_disabled_when_non_existent_interface_is_configured(self):
         registry = getUtility(IRegistry)
         reg_proxy = registry.forInterface(IZipExportSettings)
-        reg_proxy.enabled_dotted_name = u"some.other.interface"
+        reg_proxy.enabled_dotted_names = [u"some.non.existent.interface"]
 
         enabled_view = self.file.restrictedTraverse("@@zipexport-enabled")
 
@@ -46,10 +46,33 @@ class TestExportView(TestCase):
     def test_export_is_disabled_when_unprovided_interface_is_configured(self):
         registry = getUtility(IRegistry)
         reg_proxy = registry.forInterface(IZipExportSettings)
-        reg_proxy.enabled_dotted_name = u"OFS.interfaces.IFolder"
+        reg_proxy.enabled_dotted_names = [u"OFS.interfaces.IFolder"]
 
         enabled_view = self.file.restrictedTraverse("@@zipexport-enabled")
         self.assertFalse(enabled_view.zipexport_enabled())
 
         export_view = self.file.restrictedTraverse("zip_export")
         self.assertRaises(NotFound, export_view)
+
+
+    def test_export_with_multiple_configured_interfaces(self):
+        registry = getUtility(IRegistry)
+        reg_proxy = registry.forInterface(IZipExportSettings)
+        reg_proxy.enabled_dotted_names = [
+            u"OFS.interfaces.IFolder",
+            u"Products.ATContentTypes.interfaces.file.IATFile"]
+
+        export = self.file.restrictedTraverse("@@zipexport-enabled")
+
+        self.assertTrue(export.zipexport_enabled())
+
+    def test_export_with_multiple_and_nonexistent_interfaces(self):
+        registry = getUtility(IRegistry)
+        reg_proxy = registry.forInterface(IZipExportSettings)
+        reg_proxy.enabled_dotted_names = [
+            u"some.non.existent.interface",
+            u"Products.ATContentTypes.interfaces.file.IATFile"]
+
+        export = self.file.restrictedTraverse("@@zipexport-enabled")
+
+        self.assertTrue(export.zipexport_enabled())

--- a/ftw/zipexport/upgrades/configure.zcml
+++ b/ftw/zipexport/upgrades/configure.zcml
@@ -20,4 +20,22 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        name="1101"
+        title="ftw.zipexport: upgrade profile 1101"
+        description=""
+        directory="profiles/1101"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:upgradeStep
+        title="Exchange registry entry with a multivalued one."
+        description=""
+        source="1100"
+        destination="1101"
+        handler="ftw.zipexport.upgrades.to1101.UpgradeRegistry"
+        profile="ftw.zipexport:default"
+        />
+
 </configure>

--- a/ftw/zipexport/upgrades/profiles/1101/registry.xml
+++ b/ftw/zipexport/upgrades/profiles/1101/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+    <records interface="ftw.zipexport.interfaces.IZipExportSettings">
+        <value key="enabled_dotted_names"></value>
+    </records>
+</registry>

--- a/ftw/zipexport/upgrades/to1101.py
+++ b/ftw/zipexport/upgrades/to1101.py
@@ -1,0 +1,26 @@
+from ftw.upgrade import UpgradeStep
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from ftw.zipexport.interfaces import IZipExportSettings
+
+
+class UpgradeRegistry(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile('profile-ftw.zipexport.upgrades:1101')
+
+        registry = getUtility(IRegistry)
+
+        DOTTED_NAME_KEY = 'ftw.zipexport.interfaces.IZipExportSettings.enabled_dotted_name'
+
+        try:
+            old_value = registry[DOTTED_NAME_KEY]
+        except KeyError:
+            # registy has already been changed
+            pass
+        else:
+            zip_settings = registry.forInterface(IZipExportSettings)
+            zip_settings.enabled_dotted_names = [old_value]
+
+            #Unregister the old dotted name setting
+            del registry.records[DOTTED_NAME_KEY]


### PR DESCRIPTION
Currently there can be define one, and only one, interface on which the zip export is available.

Extend this so that a list of interfaces can be configured.
