### PR TITLE
Fix Plone 4.2 testing regressions with primary fields.

### DIFF
--- a/ftw/zipexport/tests/test_dexterity_representation.py
+++ b/ftw/zipexport/tests/test_dexterity_representation.py
@@ -12,6 +12,8 @@ from plone.dexterity.interfaces import IDexterityItem
 from plone.directives import form
 from plone.namedfile import field
 from plone.namedfile.file import NamedBlobFile
+from plone.rfc822.interfaces import IPrimaryField
+from Products.CMFPlone.utils import getFSVersionTuple
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
@@ -24,6 +26,11 @@ class INoteSchemaPrimary(form.Schema):
         required=False,
         )
 alsoProvides(INoteSchemaPrimary, IDexterityItem)
+
+
+if getFSVersionTuple() < (4, 3):
+    # Marshalling was not triggered in Plone 4.2 without grokking.
+    alsoProvides(INoteSchemaPrimary['blob'], IPrimaryField)
 
 
 class IInvitationSchemaNonPrimary(form.Schema):

--- a/ftw/zipexport/tests/test_dexterity_representation_namedfile.py
+++ b/ftw/zipexport/tests/test_dexterity_representation_namedfile.py
@@ -13,6 +13,8 @@ from plone.dexterity.interfaces import IDexterityItem
 from plone.directives import form
 from plone.namedfile import field
 from plone.namedfile.file import NamedFile
+from plone.rfc822.interfaces import IPrimaryField
+from Products.CMFPlone.utils import getFSVersionTuple
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
@@ -25,6 +27,11 @@ class INamedFileSchema(form.Schema):
         required=False,
         )
 alsoProvides(INamedFileSchema, IDexterityItem)
+
+
+if getFSVersionTuple() < (4, 3):
+    # Marshalling was not triggered in Plone 4.2 without grokking.
+    alsoProvides(INamedFileSchema['named_file'], IPrimaryField)
 
 
 class NamedFileBuilder(DexterityBuilder):


### PR DESCRIPTION
The supermodel marshalling was not triggered automatically in Plone 4.2,
therefore primary fields were not marked properly unless the schema was
grokked.

The fields are now marked manually for Plone < 4.3 in tests.
