### PR TITLE
Added check if fs has enough space to create the zip file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added check if fs has enough space to create the zip file.
+  [lknoepfel]
 
 
 1.2.2 (2015-03-25)

--- a/ftw/zipexport/browser/zipexportview.py
+++ b/ftw/zipexport/browser/zipexportview.py
@@ -1,13 +1,14 @@
 from ftw.zipexport import _
+from ftw.zipexport.generation import NotEnoughSpaceOnDiskException
 from ftw.zipexport.generation import ZipGenerator
 from ftw.zipexport.interfaces import IZipRepresentation
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from zExceptions import NotFound
+from zipfile import LargeZipFile
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 from ZPublisher.Iterators import filestream_iterator
-from zipfile import LargeZipFile
 import os
 
 
@@ -29,6 +30,13 @@ class ZipSelectedExportView(BrowserView):
             messages = IStatusMessage(self.request)
             messages.add(_("statmsg_no_exportable_content_selected",
                            default=u"No zip-exportable content selected."),
+                         type=u"error")
+            return self.request.response.redirect(self.context.absolute_url())
+        except NotEnoughSpaceOnDiskException:
+            messages = IStatusMessage(self.request)
+            messages.add(_("statmsg_not_enough_space_on_disk",
+                           default=u"There is not enough free space on the "
+                           "disk to create the zip-file."),
                          type=u"error")
             return self.request.response.redirect(self.context.absolute_url())
 
@@ -87,5 +95,12 @@ class ZipExportView(ZipSelectedExportView):
             messages.add(_("statmsg_no_exportable_content_found",
                            default=u"No zip-exportable content "
                            "has been found."),
+                         type=u"error")
+            return self.request.response.redirect(self.context.absolute_url())
+        except NotEnoughSpaceOnDiskException:
+            messages = IStatusMessage(self.request)
+            messages.add(_("statmsg_not_enough_space_on_disk",
+                           default=u"There is not enough free space on the "
+                           "disk to create the zip-file."),
                          type=u"error")
             return self.request.response.redirect(self.context.absolute_url())

--- a/ftw/zipexport/locales/de/LC_MESSAGES/ftw.zipexport.po
+++ b/ftw/zipexport/locales/de/LC_MESSAGES/ftw.zipexport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-13 13:59+0000\n"
+"POT-Creation-Date: 2015-04-15 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,16 +22,23 @@ msgid "Export data from plone into a zip archive."
 msgstr "Exportiert Inhalte aus Plone als Zip-Archiv."
 
 #. Default: "No zip-exportable content has been found."
-#: ./ftw/zipexport/browser/zipexportview.py:93
+#: ./ftw/zipexport/browser/zipexportview.py:95
 msgid "statmsg_no_exportable_content_found"
 msgstr "Es konnte keine Zip-Datei erstellt werden, da kein Inhalt gefunden wurde, welcher als Zip-Datei exportiert werden kann."
 
 #. Default: "No zip-exportable content selected."
-#: ./ftw/zipexport/browser/zipexportview.py:33
+#: ./ftw/zipexport/browser/zipexportview.py:31
 msgid "statmsg_no_exportable_content_selected"
 msgstr "Es wurde kein Inhalt ausgewählt, der als Zip-Datei exportiert werden kann."
 
+#. Default: "There is not enough free space on the disk to create the zip-file."
+#: ./ftw/zipexport/browser/zipexportview.py:37
+msgid "statmsg_not_enough_space_on_disk"
+msgstr "Nicht genug freier Speicher vorhanden um die Zip-Datei zu erstellen."
+
 #. Default: "Content is too big to export"
-#: ./ftw/zipexport/browser/zipexportview.py:59
+#: ./ftw/zipexport/browser/zipexportview.py:64
 msgid "statmsg_zip_file_too_big"
 msgstr "Der Inhalt ist für den Zip-Export zu gross."
+
+

--- a/ftw/zipexport/locales/fr/LC_MESSAGES/ftw.zipexport.po
+++ b/ftw/zipexport/locales/fr/LC_MESSAGES/ftw.zipexport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-13 13:59+0000\n"
+"POT-Creation-Date: 2015-04-15 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,16 +22,23 @@ msgid "Export data from plone into a zip archive."
 msgstr "Exportation de données de Plone dans des archives ZIP."
 
 #. Default: "No zip-exportable content has been found."
-#: ./ftw/zipexport/browser/zipexportview.py:93
+#: ./ftw/zipexport/browser/zipexportview.py:95
 msgid "statmsg_no_exportable_content_found"
 msgstr "L'exportation ZIP n'est pas soutenue pour le contenu choisi."
 
 #. Default: "No zip-exportable content selected."
-#: ./ftw/zipexport/browser/zipexportview.py:33
+#: ./ftw/zipexport/browser/zipexportview.py:31
 msgid "statmsg_no_exportable_content_selected"
 msgstr "L'exportation ZIP n'est pas soutenue pour le contenu choisi."
 
+#. Default: "There is not enough free space on the disk to create the zip-file."
+#: ./ftw/zipexport/browser/zipexportview.py:37
+msgid "statmsg_not_enough_space_on_disk"
+msgstr ""
+
 #. Default: "Content is too big to export"
-#: ./ftw/zipexport/browser/zipexportview.py:59
+#: ./ftw/zipexport/browser/zipexportview.py:64
 msgid "statmsg_zip_file_too_big"
 msgstr "Le contenu est trop grand pour l'exportation ZIP."
+
+

--- a/ftw/zipexport/locales/ftw.zipexport.pot
+++ b/ftw/zipexport/locales/ftw.zipexport.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-13 13:59+0000\n"
+"POT-Creation-Date: 2015-04-15 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,17 +25,22 @@ msgid "Export data from plone into a zip archive."
 msgstr ""
 
 #. Default: "No zip-exportable content has been found."
-#: ./ftw/zipexport/browser/zipexportview.py:93
+#: ./ftw/zipexport/browser/zipexportview.py:95
 msgid "statmsg_no_exportable_content_found"
 msgstr ""
 
 #. Default: "No zip-exportable content selected."
-#: ./ftw/zipexport/browser/zipexportview.py:33
+#: ./ftw/zipexport/browser/zipexportview.py:31
 msgid "statmsg_no_exportable_content_selected"
 msgstr ""
 
+#. Default: "There is not enough free space on the disk to create the zip-file."
+#: ./ftw/zipexport/browser/zipexportview.py:37
+msgid "statmsg_not_enough_space_on_disk"
+msgstr ""
+
 #. Default: "Content is too big to export"
-#: ./ftw/zipexport/browser/zipexportview.py:59
+#: ./ftw/zipexport/browser/zipexportview.py:64
 msgid "statmsg_zip_file_too_big"
 msgstr ""
 


### PR DESCRIPTION
This PR adds a check to ensure that a zip file doesn't exceed the disk space. The check checks every time before adding a file to the zip if the new file is bigger than the available space on the current disk partition.

What happens if the disk is full? 
An error is raised and displayed to the user. Since the zip is opened inside a context manager it automatically deletes the file.

How long does the zip file life on the FS?
The zip file is created at the start of the process. `NamedTemporaryFile` is used with the context manager. The files to zip are then one by one added to the zip. Every iteration checks if there is enough free space on the disk. Once the zip is fully assembled it is passed to the download thread. This exits the context manager and the file is marked as deleted by the os (checked with `ls`). But since the download process still has an open file descriptor the file still exists. Is is probably deleted as soon as the download finishes.

@jone 