### PR TITLE
Encoding fixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not fail when exporting AT folders with titles containing umlauts
+  [fRiSi]
+
+- Fall back to object.id in case filename is not set.
+  [fRiSi]
 
 
 1.3.0 (2015-05-05)

--- a/ftw/zipexport/browser/zipexportview.py
+++ b/ftw/zipexport/browser/zipexportview.py
@@ -2,6 +2,7 @@ from ftw.zipexport import _
 from ftw.zipexport.generation import NotEnoughSpaceOnDiskException
 from ftw.zipexport.generation import ZipGenerator
 from ftw.zipexport.interfaces import IZipRepresentation
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from zExceptions import NotFound
@@ -76,7 +77,7 @@ class ZipSelectedExportView(BrowserView):
             filename = '%s.zip' % self.context.title
             response.setHeader(
                 "Content-Disposition",
-                'inline; filename="%s"' % filename.encode('utf-8'))
+                'inline; filename="%s"' % safe_unicode(filename).encode('utf-8'))
             response.setHeader("Content-type", "application/zip")
             response.setHeader(
                 "Content-Length",

--- a/ftw/zipexport/representations/archetypes.py
+++ b/ftw/zipexport/representations/archetypes.py
@@ -40,7 +40,7 @@ class FileZipRepresentation(NullZipRepresentation):
     adapts(IATFile, Interface)
 
     def get_files(self, path_prefix=u"", recursive=True, toplevel=True):
-        filename = safe_unicode(self.context.getFile().getFilename())
+        filename = safe_unicode(self.context.getFile().getFilename() or self.context.id)
         yield (u'{0}/{1}'.format(safe_unicode(path_prefix), filename),
                self.get_file_open_descriptor())
 


### PR DESCRIPTION
fixes downloading of a folder containing umlauts in the title
and adds a fallback to object ids in case an image or file has `.getFilename() == None` (had this problem with my sampledata)