### PR TITLE
Allow write-on-read for zip export requests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Allow write-on-read for zip export requests with plone.protect > 3.0
+  [Rotonen]
+
 - Add events for the ZIP exports
   [Rotonen]
 

--- a/ftw/zipexport/browser/zipexportview.py
+++ b/ftw/zipexport/browser/zipexportview.py
@@ -11,8 +11,10 @@ from zipfile import LargeZipFile
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 from zope.event import notify
+from zope.interface import alsoProvides
 from ZPublisher.Iterators import filestream_iterator
 import os
+import plone.protect.interfaces
 
 
 class NoExportableContent(Exception):
@@ -23,6 +25,9 @@ class NoExportableContent(Exception):
 class ZipSelectedExportView(BrowserView):
 
     def __call__(self):
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
         portal = getSite()
         paths = self.request.get('paths', [])
         objects = [portal.restrictedTraverse(path) for path in paths]
@@ -97,6 +102,9 @@ class ZipSelectedExportView(BrowserView):
 class ZipExportView(ZipSelectedExportView):
 
     def __call__(self):
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
         try:
             return self.zip_selected([self.context])
         except NoExportableContent:


### PR DESCRIPTION
* Explicitly require plone4.csrffixes
  * This is required to get a new enough plone.protect for Plone <4.3
  * We need to pin plone.protect, plone.keyring and plone.locking
    * I am unsure as to how to do this the most correctly currently
* Explicitly disable Plone.protect for the zip export views

Fixes #38 