### PR TITLE
Drop official support for Python 2.6

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.4.1 (unreleased)
+1.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop official support for Python 2.6 [jone]
 
 
 1.4.0 (2016-12-12)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.4.1.dev0'
+version = '1.5.0.dev0'
 
 maintainer = 'Lukas Knoepfel'
 
@@ -51,7 +51,7 @@ setup(name='ftw.zipexport',
         'Products.CMFCore',
         'setuptools',
         'ftw.upgrade',
-        'path.py<9.0'
+        'path.py'
         # -*- Extra requirements: -*-
         ],
       tests_require=tests_require,

--- a/test-plone-4.2.x-py2.6.cfg
+++ b/test-plone-4.2.x-py2.6.cfg
@@ -1,8 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-jenkins_python = $PYTHON26
-
-package-name = ftw.zipexport


### PR DESCRIPTION
The official Python 2.6 support is dropped (as in: no longer tested) in order to drop the ``path.py`` compatibility constraint.

The package may still work with Python 2.6, but we may not preserve compatibility in the future.

Closes #40