### PR TITLE
Include empty folders by default and add possibility to deactivate this behavior.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Include empty folders by default and add possibility to deactivate this behavior. [elioschmutz]
 
 
 1.5.0 (2016-12-15)

--- a/ftw/zipexport/generation.py
+++ b/ftw/zipexport/generation.py
@@ -5,6 +5,7 @@ from Products.CMFPlone.utils import safe_unicode
 from tempfile import NamedTemporaryFile
 import os
 import sys
+import zipfile
 
 
 class NotEnoughSpaceOnDiskException(IOError):
@@ -32,6 +33,17 @@ class ZipGenerator(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.zip_file.__exit__(exc_type, exc_value, traceback)
         self.tmp_file.__exit__(exc_type, exc_value, traceback)
+
+    def add_folder(self, folder_path):
+        folder_path = safe_unicode(folder_path)
+
+        # Always add a slash at the end of the path
+        folder_path = u'{}/'.format(folder_path.strip('/'))
+
+        # Creates a new empty folder
+        self.zip_file.writestr(zipfile.ZipInfo(folder_path), '')
+
+        self.empty = False
 
     def add_file(self, file_path, file_pointer):
         if self.path_normalizer is not None:

--- a/ftw/zipexport/interfaces.py
+++ b/ftw/zipexport/interfaces.py
@@ -9,6 +9,11 @@ class IZipExportSettings(Interface):
         default=[u"Products.CMFCore.interfaces._content.IContentish"],
         value_type=schema.TextLine())
 
+    include_empty_folders = schema.Bool(
+        title=u"Include empty folders in zipexport.",
+        description=u"Defines if empty folders should be included in the export or not",
+        default=True)
+
 
 class IZipRepresentation(Interface):
     """ Represents list of files to zip. """

--- a/ftw/zipexport/representations/archetypes.py
+++ b/ftw/zipexport/representations/archetypes.py
@@ -27,6 +27,10 @@ class FolderZipRepresentation(NullZipRepresentation):
             path_prefix = u'{0}/{1}'.format(safe_unicode(path_prefix),
                                             safe_unicode(self.context.Title()))
 
+        if not content:
+            # Creates an empty folder
+            yield (path_prefix, None)
+
         for obj in content:
             adapt = getMultiAdapter((obj, self.request),
                                     interface=IZipRepresentation)

--- a/ftw/zipexport/tests/test_generaton.py
+++ b/ftw/zipexport/tests/test_generaton.py
@@ -41,6 +41,12 @@ class TestZipGeneration(TestCase):
             or (os.stat(generated_zip_pointer.name).st_size == 0)):
                 raise AssertionError()
 
+    def test_add_folder_will_create_a_new_folder(self):
+        with ZipGenerator() as zipgenerator:
+            zipgenerator.add_folder('Documents')
+
+            self.assertEqual(['Documents/'], zipgenerator.zip_file.namelist())
+
     def test_generator_raises_exception_when_not_used_as_generator(self):
         zipgenerator = ZipGenerator()
         self.assertRaises(StandardError, zipgenerator.generate)

--- a/ftw/zipexport/upgrades/20170816165904_include_empty_folders_in_export/registry.xml
+++ b/ftw/zipexport/upgrades/20170816165904_include_empty_folders_in_export/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <records interface="ftw.zipexport.interfaces.IZipExportSettings" />
+</registry>

--- a/ftw/zipexport/upgrades/20170816165904_include_empty_folders_in_export/upgrade.py
+++ b/ftw/zipexport/upgrades/20170816165904_include_empty_folders_in_export/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class IncludeEmptyFoldersInExport(UpgradeStep):
+    """Include empty folders in export.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
![bildschirmfoto 2017-08-16 um 17 44 05](https://user-images.githubusercontent.com/557005/29372092-74a12bc6-82aa-11e7-95ae-f6cb4b0a0038.png)

closes #44 
required in https://github.com/4teamwork/opengever.core/issues/3285