### PR TITLE
Fix encoding bug when zip filename contains umlauts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix encoding bug when zip filename contains umlauts. [phgross]
 
 
 1.6.0 (2017-08-17)

--- a/ftw/zipexport/browser/zipexportview.py
+++ b/ftw/zipexport/browser/zipexportview.py
@@ -5,9 +5,9 @@ from ftw.zipexport.generation import ZipGenerator
 from ftw.zipexport.interfaces import IZipExportSettings
 from ftw.zipexport.interfaces import IZipRepresentation
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
+from rfc6266 import build_header
 from zExceptions import NotFound
 from zipfile import LargeZipFile
 from zope.component import getMultiAdapter
@@ -90,15 +90,13 @@ class ZipSelectedExportView(BrowserView):
             notify(ContainerZippedEvent(self.context))
 
             # Generate response file
-            filename = '%s.zip' % self.context.title
+            filename = u'%s.zip' % self.context.title
             response.setHeader(
                 "Content-Disposition",
-                'inline; filename="{0}"'.format(
-                    safe_unicode(filename).encode('utf-8')))
+                build_header(filename, disposition='attachment'))
             response.setHeader("Content-type", "application/zip")
-            response.setHeader(
-                "Content-Length",
-                os.stat(zip_file.name).st_size)
+            response.setHeader("Content-Length",
+                               os.stat(zip_file.name).st_size)
 
             return filestream_iterator(zip_file.name, 'rb')
 

--- a/ftw/zipexport/tests/test_exportview.py
+++ b/ftw/zipexport/tests/test_exportview.py
@@ -59,6 +59,12 @@ class TestExportView(TestCase):
         zipfile = ZipFile(StringIO(self.browser.contents), 'r')
         self.assertEquals(["testdata.txt"], zipfile.namelist())
 
+    def test_content_disposition_for_non_ascii_characters(self):
+        self.browser.open("%s/zip_export" % self.emptyfolder.absolute_url())
+        self.assertEquals(
+            "attachment; filename*=utf-8''Empty%20f%C3%B6lder.zip",
+        self.browser.headers.get('Content-Disposition'))
+
     def test_zip_multiple_files_in_folder(self):
         self.browser.open("%s/zip_export" % self.folder.absolute_url())
         zipfile = ZipFile(StringIO(self.browser.contents), 'r')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(name='ftw.zipexport',
         'Products.CMFCore',
         'setuptools',
         'ftw.upgrade',
-        'path.py'
+        'path.py',
+        'rfc6266',
         # -*- Extra requirements: -*-
         ],
       tests_require=tests_require,


### PR DESCRIPTION
Create Content-Disposition header with the help of the [rfc6266](https://github.com/g2p/rfc6266) modul, to make sure filename is encoded correctly also on internet explorer.

Before: 
![bildschirmfoto 2017-09-05 um 22 05 50](https://user-images.githubusercontent.com/485755/30081187-7d66024a-9286-11e7-965b-e58058468363.png)
After:
![bildschirmfoto 2017-09-05 um 22 05 58](https://user-images.githubusercontent.com/485755/30081186-7d43c860-9286-11e7-90ab-2488e4c6984d.png)