### PR TITLE
Remove wrong allowed check on context for zip selected view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Remove wrong allowed check on context for zip selected view. [phgross]
 
 1.5.0 (2016-12-15)
 ------------------

--- a/ftw/zipexport/browser/zipexportview.py
+++ b/ftw/zipexport/browser/zipexportview.py
@@ -46,13 +46,6 @@ class ZipSelectedExportView(BrowserView):
     def zip_selected(self, objects):
         response = self.request.response
 
-        # check if zipexport is allowed on this context
-        enabled_view = getMultiAdapter((self.context, self.request),
-                                       name=u'zipexport-enabled')
-
-        if not enabled_view.zipexport_enabled():
-            raise NotFound()
-
         with ZipGenerator() as generator:
 
             for obj in objects:
@@ -97,6 +90,13 @@ class ZipSelectedExportView(BrowserView):
 class ZipExportView(ZipSelectedExportView):
 
     def __call__(self):
+        # check if zipexport is allowed on this context
+        enabled_view = getMultiAdapter((self.context, self.request),
+                                       name=u'zipexport-enabled')
+
+        if not enabled_view.zipexport_enabled():
+            raise NotFound()
+
         try:
             return self.zip_selected([self.context])
         except NoExportableContent:

--- a/ftw/zipexport/tests/test_export_limitation.py
+++ b/ftw/zipexport/tests/test_export_limitation.py
@@ -54,6 +54,10 @@ class TestExportView(TestCase):
         export_view = self.file.restrictedTraverse("zip_export")
         self.assertRaises(NotFound, export_view)
 
+        # selected view does not check if the zip export is enabled on
+        # current context
+        zip_selected_view = self.file.restrictedTraverse("zip_selected")
+        zip_selected_view()
 
     def test_export_with_multiple_configured_interfaces(self):
         registry = getUtility(IRegistry)


### PR DESCRIPTION
The current check on the selected_objects view, does not make any sense. It doesn't matter if the current context (where the objects has been selected) supports ZIP export or not.

Example: We got a listing on the PloneSite where documents can be selected to include in a zip export. So the zip_selected view should be available on the PloneSite but the `Export as ZIP` should definitely not be available. 