### PR TITLE
Normalize also folder paths not only file path.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix doubled subfolders when a folder with umlaut in the title contains empty subfolders. [phgross]
 
 
 1.6.3 (2018-04-17)

--- a/ftw/zipexport/generation.py
+++ b/ftw/zipexport/generation.py
@@ -35,6 +35,9 @@ class ZipGenerator(object):
         self.tmp_file.__exit__(exc_type, exc_value, traceback)
 
     def add_folder(self, folder_path):
+        if self.path_normalizer is not None:
+            folder_path = self.path_normalizer(folder_path)
+
         folder_path = safe_unicode(folder_path)
 
         # Always add a slash at the end of the path

--- a/ftw/zipexport/tests/test_exportview.py
+++ b/ftw/zipexport/tests/test_exportview.py
@@ -76,7 +76,7 @@ class TestExportView(TestCase):
         self.browser.open("%s/zip_export" % self.superfolder.absolute_url())
         zipfile = ZipFile(StringIO(self.browser.contents), 'r')
         self.assertEquals(
-            ['SUPERFILE', 'Folder/testdata.txt', 'Folder/moretest.data', u'Empty f\xf6lder/'],
+            ['SUPERFILE', 'Folder/testdata.txt', 'Folder/moretest.data', u'Empty folder/'],
             zipfile.namelist())
 
     def test_zip_selected_files(self):

--- a/ftw/zipexport/tests/test_generaton.py
+++ b/ftw/zipexport/tests/test_generaton.py
@@ -93,11 +93,12 @@ class TestZipGeneration(TestCase):
                 [u'file.txt', u'file (2).txt', u'file (3).txt'],
                 in_zip_file_list)
 
-    def test_filenames_are_normalized(self):
+    def test_filename_and_folders_are_normalized(self):
         with ZipGenerator() as zipgenerator:
-            zipgenerator.add_file('F\xc3\xbc\xc3\xb6 B\xc3\xa4r.tar.gz', StringIO())
+            zipgenerator.add_folder('t\xc3\xb6mp')
+            zipgenerator.add_file('t\xc3\xb6mp/F\xc3\xbc\xc3\xb6 B\xc3\xa4r.tar.gz', StringIO())
             self.assertItemsEqual(
-                [u'Fuo Bar.tar.gz'],
+                [u'tomp/', 'tomp/Fuo Bar.tar.gz'],
                 zipgenerator.zip_file.namelist())
 
     def test_normalization_can_be_disabled(self):


### PR DESCRIPTION
This fix an issues where some subfolders gets doubled, when they have a title with umlauts and containing empty subfolders.

For https://github.com/4teamwork/opengever.core/issues/5941