### PR TITLE
Use pathprefix for selected folders in zip_export view

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -35,13 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,36 +63,57 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
-
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
-    # this will remove them from the path to ensure that incompatible versions 
+    # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
-    # inside a virtualenv, there is no 'getsitepackages'. 
+    # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
 ez['use_setuptools'](**setup_args)
 import setuptools
 import pkg_resources
@@ -104,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -117,21 +147,23 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -156,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Exporting selected folders will now preserve the folder structure on the top level. [elioschmutz]
 
 
 1.6.4 (2019-09-19)

--- a/ftw/zipexport/browser/zipexportview.py
+++ b/ftw/zipexport/browser/zipexportview.py
@@ -5,6 +5,8 @@ from ftw.zipexport.generation import ZipGenerator
 from ftw.zipexport.interfaces import IZipExportSettings
 from ftw.zipexport.interfaces import IZipRepresentation
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.interfaces._content import IFolderish
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from rfc6266 import build_header
@@ -56,7 +58,11 @@ class ZipSelectedExportView(BrowserView):
                 repre = getMultiAdapter((obj, self.request),
                                         interface=IZipRepresentation)
 
-                for path, pointer in repre.get_files():
+                path_prefix = ''
+                if IFolderish.providedBy(obj) and obj is not self.context:
+                    path_prefix = safe_unicode(obj.Title())
+
+                for path, pointer in repre.get_files(path_prefix=path_prefix):
                     if not pointer:
                         if settings.include_empty_folders:
                             generator.add_folder(path)

--- a/ftw/zipexport/tests/test_exportview.py
+++ b/ftw/zipexport/tests/test_exportview.py
@@ -89,6 +89,15 @@ class TestExportView(TestCase):
             ['testdata.txt', 'moretest.data'],
             zipfile.namelist())
 
+    def test_zip_selected_folder_with_files(self):
+        postdata = "zip_selected:method=1&paths:list=%s&" % (
+            '/'.join(self.folder.getPhysicalPath()))
+        self.browser.open(self.superfolder.absolute_url(), postdata)
+        zipfile = ZipFile(StringIO(self.browser.contents), 'r')
+        self.assertEquals(
+            ['Folder/testdata.txt', 'Folder/moretest.data'],
+            zipfile.namelist())
+
     def test_exclude_empty_folders_if_setting_is_deactivated(self):
         registry = getUtility(IRegistry)
         registry.forInterface(IZipExportSettings).include_empty_folders = False


### PR DESCRIPTION
This PR fixes an issue where the folder structure gets lost when exporting folders by selection.

Having the following structure:

- Folder
  - Subfolder 1
    - Doc 1
  - Subfolder 2
    - Doc 2
    - Doc 3

When we now call the `@zip_export` view on the `Folder`, it will create a zip called `Folder` with the expected content:

![Bildschirmfoto 2023-09-08 um 08 00 40](https://github.com/4teamwork/ftw.zipexport/assets/557005/b8826a82-22d7-4996-a0d1-c63067b05d6b)

But when calling the `@zip_export` view on the `Folder` with path-selection of `Subfolder 1` and `Subfolder 2`, we'll get a flat list of documents. This PR fixes this issue by using a path prefix on selected folders:

## Before
![Bildschirmfoto 2023-09-08 um 08 09 31](https://github.com/4teamwork/ftw.zipexport/assets/557005/9aef1429-3010-4ff4-9f84-0209f4a6c886)

## After
![Bildschirmfoto 2023-09-08 um 08 00 40](https://github.com/4teamwork/ftw.zipexport/assets/557005/b8826a82-22d7-4996-a0d1-c63067b05d6b)

For: https://4teamwork.atlassian.net/browse/CA-5554